### PR TITLE
Fixes namespace for console application and MatcherBundles base paths

### DIFF
--- a/bin/typo3scan
+++ b/bin/typo3scan
@@ -25,7 +25,7 @@
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
-use MichielRoos\TYPO3Scan\Command\Application;
+use MichielRoos\TYPO3Scan\Console\Application;
 
 $app = new Application('TYPO3Scan', '1.3.0');
 $app->add(new \MichielRoos\TYPO3Scan\Command\ScanCommand);

--- a/src/TYPO3Scan/Console/Application.php
+++ b/src/TYPO3Scan/Console/Application.php
@@ -1,5 +1,5 @@
 <?php
-namespace MichielRoos\TYPO3Scan\Command;
+namespace MichielRoos\TYPO3Scan\Console;
 
 /**
  * Copyright (c) 2018 Michiel Roos
@@ -27,7 +27,7 @@ use Symfony\Component\Console\Application as BaseApplication;
 
 /**
  * Class Application
- * @package MichielRoos\TYPO3Scan\Command
+ * @package MichielRoos\TYPO3Scan\Console
  */
 class Application extends BaseApplication
 {

--- a/src/TYPO3Scan/Service/ScannerService.php
+++ b/src/TYPO3Scan/Service/ScannerService.php
@@ -34,6 +34,11 @@ use TYPO3\CMS\Scanner\ScannerFactory;
 class ScannerService
 {
     /**
+     * @var string
+     */
+	private static $matcherBundleBasePath = __DIR__ . '/../../../vendor/typo3/cms-scanner/config/Matcher/';
+
+    /**
      * @var MatcherBundleCollection
      */
     private $collection;
@@ -52,7 +57,7 @@ class ScannerService
             case '9':
                 $this->collection = new MatcherBundleCollection(
                     new \TYPO3\CMS\Scanner\Domain\Model\MatcherBundle(
-                        __DIR__ . '/../../../vendor/typo3/cms-scanner/config/Matcher/v9',
+                        self::$matcherBundleBasePath . 'v9',
                         '',
 
                         Matcher\ArrayDimensionMatcher::class,
@@ -79,7 +84,7 @@ class ScannerService
             case '8':
                 $this->collection = new MatcherBundleCollection(
                     new \TYPO3\CMS\Scanner\Domain\Model\MatcherBundle(
-                        __DIR__ . '/../../../vendor/typo3/cms-scanner/config/Matcher/v8',
+                        self::$matcherBundleBasePath . 'v8',
                         '',
 
                         Matcher\ArrayDimensionMatcher::class,
@@ -100,7 +105,7 @@ class ScannerService
             default:
                 $this->collection = new MatcherBundleCollection(
                     new \TYPO3\CMS\Scanner\Domain\Model\MatcherBundle(
-                        __DIR__ . '/../../../vendor/typo3/cms-scanner/config/Matcher/v7',
+                        self::$matcherBundleBasePath . 'v7',
                         '',
 
                         Matcher\ArrayMatcher::class,


### PR DESCRIPTION
Hi Michiel, 

while testing the tool - after manually fixing the binary path issue, which I saw is already fixed, I came across an incorrect namespace for the console application. 

Not sure about the second commit containing a fix about the MatcherBundle base path, but in my case, with manually fixed binary, the directory path was incorrect. But I have to admit that I have not examined this in detail.

If something should not fit as desired or if there are any questions or suggestions, just let me know. 

Regards, 
Marcel