### PR TITLE
[BUGFIX] Infinite loop on Windows path

### DIFF
--- a/src/TYPO3Scan/Command/ScanCommand.php
+++ b/src/TYPO3Scan/Command/ScanCommand.php
@@ -219,7 +219,11 @@ EOT
             if ($dir === 'ext') {
                 return true;
             }
-            $path = \dirname($path);
+            $newPath = \dirname($path);
+            if ($newPath === $path) {
+                break;
+            }
+            $path = $newPath;
         }
         return false;
     }


### PR DESCRIPTION
Fixes an infinite loop when a windows path is given.

(`\dirname($path)` is never empty, as `D:\foo\bar` will be reduced to `D` and then gets stuck. 