### PR TITLE
Fix headline in Markdown template

### DIFF
--- a/src/Resources/Private/Templates/Markdown.twig
+++ b/src/Resources/Private/Templates/Markdown.twig
@@ -1,4 +1,4 @@
-#{{ title }}
+# {{ title }}
 
 Found **{{ total }}** matches in **{{ executionTime|number_format(2) }}s** when
 checking for changes and deprecations in **TYPO3 {{ targetVersion }}**


### PR DESCRIPTION
The asterisk in Markdown must be followed by a space before the title begins.
Otherwise e.g. GitLab tries to parse the asterisk and the following text as
a reference to an issue.