### PR TITLE
Add "--fail-on-match" CLI option

### DIFF
--- a/src/TYPO3Scan/Command/ScanCommand.php
+++ b/src/TYPO3Scan/Command/ScanCommand.php
@@ -60,6 +60,7 @@ class ScanCommand extends Command
                 new InputOption('format', 'f', InputOption::VALUE_OPTIONAL, 'Output format', 'plain'),
                 new InputOption('reportFile', 'r', InputOption::VALUE_OPTIONAL, 'Report file', null),
                 new InputOption('templatePath', null, InputOption::VALUE_OPTIONAL, 'Path to template folder'),
+                new InputOption('failOnMatch', null, InputOption::VALUE_NONE, 'Fail if there are matches, useful for CI checks', false),
             ])
             ->setHelp(<<<EOT
 The <info>scan</info> command scans a path for deprectated code</info>.
@@ -84,6 +85,9 @@ Scan a folder for v9 changes and output in markdown with custom template:
 
 Scan a folder for v7 changes, only show the breaking changes and output in markdown:
 <info>php typo3scan.phar scan --target 7 --only breaking --format markdown ~/tmp/source</info>
+
+Scan a folder for changes, fail if there are matches (useful for CI checks):
+<info>php typo3scan.phar scan --target 10 --only breaking --fail-on-match ~/tmp/source</info>
 EOT
             );
     }
@@ -94,7 +98,7 @@ EOT
      * @param InputInterface $input
      * @param OutputInterface $output
      *
-     * @return void|int
+     * @return int
      * @throws \Twig_Error_Loader
      * @throws \Twig_Error_Runtime
      * @throws \Twig_Error_Syntax
@@ -183,6 +187,12 @@ EOT
         } else {
             $output->write($template->render($context));
         }
+        
+        if ($total > 0 && $input->getOption('failOnMatch')) {
+            return 1;
+        }
+        
+        return 0;
     }
 
     /**


### PR DESCRIPTION
When set, this option lets the "scan" command fail which is useful for automated CI checks.